### PR TITLE
feat: implement header arg Refs: #2

### DIFF
--- a/android/src/main/java/com/websocketselfsigned/WebsocketSelfSignedModule.kt
+++ b/android/src/main/java/com/websocketselfsigned/WebsocketSelfSignedModule.kt
@@ -4,7 +4,6 @@ import com.facebook.react.bridge.*
 import com.facebook.react.modules.core.DeviceEventManagerModule
 import okhttp3.*
 import okio.ByteString
-import okio.ByteString.Companion.decodeBase64
 import java.security.cert.X509Certificate
 import javax.net.ssl.*
 
@@ -34,9 +33,27 @@ class WebSocketWithSelfSignedCertModule(reactContext: ReactApplicationContext) :
         return "WebSocketWithSelfSignedCert"
     }
 
+    /**
+     * Connect to the specified WebSocket URL with optional headers.
+     * Example call from JS:
+     * WebSocketWithSelfSignedCert.connect("wss://your-url", { Authorization: "Bearer token", "Custom-Header": "Value" })
+     */
     @ReactMethod
-    fun connect(url: String, promise: Promise) {
-        val request = Request.Builder().url(url).build()
+    fun connect(url: String, headers: ReadableMap, promise: Promise) {
+        val requestBuilder = Request.Builder().url(url)
+
+        // Add headers from the ReadableMap
+        val iterator = headers.keySetIterator()
+        while (iterator.hasNextKey()) {
+            val key = iterator.nextKey()
+            val value = headers.getString(key)
+            if (value != null) {
+                requestBuilder.addHeader(key, value)
+            }
+        }
+
+        val request = requestBuilder.build()
+
         webSocket = client.newWebSocket(request, object : WebSocketListener() {
             override fun onOpen(webSocket: WebSocket, response: Response) {
                 sendEvent("onOpen", null)

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1209,7 +1209,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-websocket-self-signed (0.1.0):
+  - react-native-websocket-self-signed (0.2.1):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2024.01.01.00)
@@ -1739,7 +1739,7 @@ SPEC CHECKSUMS:
   React-logger: 8db32983d75dc2ad54f278f344ccb9b256e694fc
   React-Mapbuffer: 1c08607305558666fd16678b85ef135e455d5c96
   React-microtasksnativemodule: e8efd9e5df1ab51a58e45326b98787cf21d47e6e
-  react-native-websocket-self-signed: f93db5f01425e820b8e718ed514c0355b95393c8
+  react-native-websocket-self-signed: b6400162dcd9e6c2480f552620c50a81170371a8
   React-nativeconfig: 57781b79e11d5af7573e6f77cbf1143b71802a6d
   React-NativeModulesApple: e35ceb132b4005f4bb8924a3a87b9fd3c21b15ee
   React-perflogger: 8a360ccf603de6ddbe9ff8f54383146d26e6c936

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -58,7 +58,7 @@ const App: React.FC = () => {
     });
 
     wsWithSelfSignedCert
-      .connect(targetWebSocket)
+      .connect(targetWebSocket, { Authorization: 'Bearer your_token' })
       .then((data) => {
         console.log('Connected to WebSocketWithSelfSignedCert', data);
         setConnected(true);

--- a/ios/WebsocketSelfSigned.mm
+++ b/ios/WebsocketSelfSigned.mm
@@ -2,7 +2,10 @@
 #import <React/RCTEventEmitter.h>
 
 @interface RCT_EXTERN_MODULE(WebSocketWithSelfSignedCert, RCTEventEmitter)
-RCT_EXTERN_METHOD(connect:(NSString *)url resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(connect:(NSString *)url
+                  headers:(NSDictionary *)headers
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(send:(NSString *)message)
 RCT_EXTERN_METHOD(close)
 @end

--- a/ios/WebsocketSelfSigned.swift
+++ b/ios/WebsocketSelfSigned.swift
@@ -16,16 +16,28 @@ class WebSocketWithSelfSignedCert: RCTEventEmitter {
     }
 
     @objc
-    func connect(_ url: String, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+    func connect(_ url: String,
+                 headers: [String: String]?,
+                 resolver resolve: @escaping RCTPromiseResolveBlock,
+                 rejecter reject: @escaping RCTPromiseRejectBlock) {
         guard let nsUrl = URL(string: url) else {
             reject("Invalid URL", "The provided URL is not valid", nil)
             return
         }
 
+        // Create a URLRequest so we can add headers
+        var request = URLRequest(url: nsUrl)
+        if let headers = headers {
+            for (key, value) in headers {
+                request.addValue(value, forHTTPHeaderField: key)
+            }
+        }
+
         let sessionConfig = URLSessionConfiguration.default
         let session = URLSession(configuration: sessionConfig, delegate: self, delegateQueue: nil)
 
-        webSocketTask = session.webSocketTask(with: nsUrl)
+        // Use request to create the WebSocketTask
+        webSocketTask = session.webSocketTask(with: request)
         webSocketTask?.resume()
 
         // Set the connection state to true
@@ -89,7 +101,9 @@ class WebSocketWithSelfSignedCert: RCTEventEmitter {
 }
 
 extension WebSocketWithSelfSignedCert: URLSessionDelegate {
-    func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+    func urlSession(_ session: URLSession,
+                    didReceive challenge: URLAuthenticationChallenge,
+                    completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
         // Bypass SSL certificate validation and accept any certificate
         if let serverTrust = challenge.protectionSpace.serverTrust {
             let credential = URLCredential(trust: serverTrust)

--- a/src/__tests__/WebSocketSelfSignedi.test.tsx
+++ b/src/__tests__/WebSocketSelfSignedi.test.tsx
@@ -40,7 +40,16 @@ describe('WebSocketWithSelfSignedCert', () => {
     const result = await webSocket.connect('ws://example.com');
     expect(
       WebSocketWithSelfSignedCertNativeModule.connect
-    ).toHaveBeenCalledWith('ws://example.com');
+    ).toHaveBeenCalledWith('ws://example.com', {});
+    expect(result).toBe('connected');
+  });
+
+  it('should connect to WebSocket server with header', async () => {
+    const header = { Authorization: 'Bearer your_token' };
+    const result = await webSocket.connect('ws://example.com', header);
+    expect(
+      WebSocketWithSelfSignedCertNativeModule.connect
+    ).toHaveBeenCalledWith('ws://example.com', header);
     expect(result).toBe('connected');
   });
 

--- a/src/models/WebSocketWithSelfSignedCert.ts
+++ b/src/models/WebSocketWithSelfSignedCert.ts
@@ -20,13 +20,14 @@ class WebSocketWithSelfSignedCert {
   }
 
   /**
-   * Connects to the WebSocket server at the given URL.
+   * Connects to the WebSocket server at the given URL with optional headers.
    *
    * @param url - The WebSocket server URL to connect to.
+   * @param headers - Optional headers to include in the connection request.
    * @returns A promise that resolves when the connection is successful.
    */
-  connect(url: string): Promise<string> {
-    return WebSocketWithSelfSignedCertNativeModule.connect(url);
+  connect(url: string, headers?: { [key: string]: string }): Promise<string> {
+    return WebSocketWithSelfSignedCertNativeModule.connect(url, headers || {});
   }
 
   /**

--- a/src/types/native-module.d.ts
+++ b/src/types/native-module.d.ts
@@ -2,7 +2,7 @@
  * The expected interface of the WebSocketWithSelfSignedCert native module.
  */
 export interface WebSocketWithSelfSignedCertNativeModuleType {
-  connect(url: string): Promise<string>;
+  connect(url: string, headers?: { [key: string]: string }): Promise<string>;
   send(message: string): void;
   close(): void;
 }


### PR DESCRIPTION
@FTCHD

## Description

I added a header arg to native module and react native module. As far as I tested, webSocket server received requested header. Now you can send the header like this.

```ts
    wsWithSelfSignedCert
      .connect(targetWebSocket, { Authorization: 'Bearer your_token' })
```

Or without header

```ts
    wsWithSelfSignedCert
      .connect(targetWebSocket)
```

I pushed a simple webSocket server to the following repository. It might be helpful for testing. 

https://github.com/yuyak97/sample-websocket-server

## Related issue
- passing headers #2
